### PR TITLE
Simplify ATPOutputView close method

### DIFF
--- a/lib/atp-view.coffee
+++ b/lib/atp-view.coffee
@@ -859,11 +859,8 @@ class ATPOutputView extends View
       }, 250, =>
         @attr 'style', ''
         @consoleToolbar.attr 'style', ''
-        @detach()
-        lastOpenedView = null
-    else
-      @detach()
-      lastOpenedView = null
+    @detach()
+    lastOpenedView = null
 
 
   toggle: ->


### PR DESCRIPTION
The detach() and lastOpenedView = null should occur regardless of the
outcome of the conditional. It is cleaner to just have these lines
follow the after the if statement.

Coincidentally, this fixes isis97/atom-terminal-panel#57 which allowed
multiple panels to be open at the same time.