### PR TITLE
Refactor terminal output

### DIFF
--- a/lib/atp-builtins-commands.coffee
+++ b/lib/atp-builtins-commands.coffee
@@ -48,7 +48,10 @@ module.exports =
   "cd":
     "params": "[directory]"
     "description": "Moves to the specified directory."
-    "command": (state, args)-> state.cd args
+    "command": (state, args)->
+      ret = state.cd args
+      if not ret?
+        state.statusIcon.addClass 'status-success'
   "new":
     "description": "Creates a new file and opens it in the editor view."
     "command": (state, args)->

--- a/lib/atp-view.coffee
+++ b/lib/atp-view.coffee
@@ -731,7 +731,6 @@ class ATPOutputView extends View
 
   clear: ->
     @cliOutput.empty()
-    @message '\n'
     @putInputBox()
 
   setMaxWindowHeight: ->

--- a/lib/atp-view.coffee
+++ b/lib/atp-view.coffee
@@ -803,7 +803,6 @@ class ATPOutputView extends View
       @program.kill('SIGINT')
       @program.kill()
       @message (@consoleLabel 'info', 'info')+(@consoleText 'info', 'Process has been stopped')
-      @message '\n'
 
   maximize: ->
     @cliOutput.height (@cliOutput.height()+9999)
@@ -1378,9 +1377,7 @@ class ATPOutputView extends View
           @statusIcon.addClass 'status-error'
           if code == 127
             @message (@consoleLabel 'error', 'Error')+(@consoleText 'error', @program.cmd + ': command not found')
-          else
-            @message (@consoleLabel 'error', 'Error')+(@consoleText 'error', 'Exit Code: ' + code)
-          @message '\n'
+            @message '\n'
         @putInputBox()
         @showCmd()
         @program = null

--- a/lib/atp-view.coffee
+++ b/lib/atp-view.coffee
@@ -1063,7 +1063,6 @@ class ATPOutputView extends View
     if atom.config.get('atom-terminal-panel.useAtomIcons')
       classes.push 'name'
       classes.push 'icon'
-      classes.push 'icon-file-text'
       dataname = filepath
     else
       classes.push 'name'

--- a/lib/atp-view.coffee
+++ b/lib/atp-view.coffee
@@ -888,8 +888,7 @@ class ATPOutputView extends View
     return text.replace(/['"]+/g, '')
 
   cd: (args)->
-    if not args[0]
-      return null
+    args = [atom.project.getPaths()[0]] if not args[0]
     args = @removeQuotes args
     dir = resolve @getCwd(), args[0]
     try
@@ -1364,7 +1363,6 @@ class ATPOutputView extends View
     try
       @program = exec inputCmd, stdio: 'pipe', env: process.env, cwd: @getCwd()
       console.log @program if atom.config.get('atom-terminal-panel.logConsole') or @specsMode
-      @program.cmd = cmd
       @program.stdout.pipe htmlStream
       @program.stderr.pipe htmlStream
 
@@ -1380,7 +1378,7 @@ class ATPOutputView extends View
         else if code?
           @statusIcon.addClass 'status-error'
           if code == 127
-            @message (@consoleLabel 'error', 'Error')+(@consoleText 'error', @program.cmd + ': command not found')
+            @message (@consoleLabel 'error', 'Error')+(@consoleText 'error', cmd + ': command not found')
             @message '\n'
         @putInputBox()
         @showCmd()


### PR DESCRIPTION
Changed how the terminal output displays command data. Commands stay
behind like in a standard terminal. If a command is not recognized, and
error is displayed. See ‘what’s new’ for a full list of changes.

What’s New:

- Entered commands stay behind in the terminal log
- If a command is not recognized, an error is displayed
- Command prompt should now appear after output
- Status icons better represent the status of a terminal
- Internal ls command displays proper file type